### PR TITLE
sidekiq-ent is not required with multiple workers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     sidekiq-staged_push (0.3.1)
       activerecord (>= 5.2.0)
       sidekiq (>= 6.5.0)
+      with_advisory_lock (>= 5.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -68,6 +69,8 @@ GEM
       nokogiri (>= 1.12.0)
     minitest (5.20.0)
     mutex_m (0.2.0)
+    nokogiri (1.16.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
@@ -153,6 +156,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
+    sqlite3 (1.7.0-arm64-darwin)
     sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     stringio (3.1.0)
@@ -162,9 +166,13 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
   x86_64-linux-musl

--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ And finally, create the tables:
 
 ## Gotchas
 
-1. The gem currently assumes that you're running only one Sidekiq process or using Sidekiq
-Enterprise. Jobs may be processed multiple times if this is not true.
-2. `SomeWorker.perform_bulk([[1], [2], [3]])` is inconsistent with other methods, because it
+1. `SomeWorker.perform_bulk([[1], [2], [3]])` is inconsistent with other methods, because it
 schedules to Redis immediately.
 
 ## Development

--- a/lib/sidekiq/staged_push.rb
+++ b/lib/sidekiq/staged_push.rb
@@ -5,6 +5,7 @@ require "sidekiq/job"
 require "sidekiq/staged_push/client"
 require "sidekiq/staged_push/enqueuer"
 require "sidekiq/staged_push/version"
+require "with_advisory_lock"
 
 module Sidekiq
   module StagedPush

--- a/sidekiq-staged_push.gemspec
+++ b/sidekiq-staged_push.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 5.2.0"
   spec.add_dependency "sidekiq", ">= 6.5.0"
+  spec.add_dependency "with_advisory_lock", ">= 5.1.0"
 end


### PR DESCRIPTION
Support multiple processes without requiring sidekiq enterprise by leveraging advisory locks.
When running multiple sidekiq processes only one thread will be able to acquire a lock and process jobs in every 200ms window.
