### PR TITLE
transaction block is instantiated only if needed

### DIFF
--- a/lib/sidekiq/staged_push/enqueuer/process_batch.rb
+++ b/lib/sidekiq/staged_push/enqueuer/process_batch.rb
@@ -10,19 +10,19 @@ module Sidekiq
         BATCH_SIZE = 500
 
         def call
+          jobs = StagedJob.order(:id).limit(BATCH_SIZE).to_a
+
+          return 0 unless jobs.present?
+
+          client = Sidekiq::Client.new
           StagedJob.transaction do
-            jobs = StagedJob.order(:id).limit(BATCH_SIZE).to_a
-
-            if jobs.present?
-              client = Sidekiq::Client.new
-              jobs.each do |job|
-                client.push(job.payload)
-              end
-              StagedJob.where(id: jobs.map(&:id)).delete_all
+            jobs.each do |job|
+              client.push(job.payload)
             end
-
-            jobs.size
+            StagedJob.where(id: jobs.map(&:id)).delete_all
           end
+
+          jobs.size
         end
       end
     end


### PR DESCRIPTION
We only need to instantiate a transaction if there are staged jobs exist.